### PR TITLE
do not use docker cache when building base image

### DIFF
--- a/playground/build.sh
+++ b/playground/build.sh
@@ -24,7 +24,7 @@ cp -p ../py3/requirements.txt ./base/requirements.txt
 
 # Rebuild all of our Docker images.
 
-docker build -t fopnp/base base
+docker build --no-cache=true -t fopnp/base base
 docker build -t fopnp/dns dns
 docker build -t fopnp/ftp ftp
 docker build -t fopnp/mail mail

--- a/playground/launch.sh
+++ b/playground/launch.sh
@@ -54,7 +54,7 @@ start_container () {
 # These commands are each a no-op if the command has already run.
 
 start_bridge () {               # args: BRIDGE_NAME
-    sudo brctl addbr $1 &>/dev/null || return
+    sudo brctl addbr $1 > /dev/null 2>&1 || return
     sudo ip link set $1 up
     echo Created bridge: $1
 }
@@ -72,7 +72,7 @@ create_interface () {
     interface=$1
     container=${interface%%-*}
     short_name=${interface##*-}
-    sudo ip link add $interface type veth peer name P &>/dev/null || return
+    sudo ip link add $interface type veth peer name P > /dev/null 2>&1 || return
     give_interface_to_container P $container $short_name
     echo Created interface: $interface
 }
@@ -82,7 +82,7 @@ create_point_to_point () {
     # interfaces and put one inside the container "backbone" and name it
     # "eth0" and the other inside of "isp" with the name "eth1".
     #
-    sudo ip netns exec $1 ip link set $2 up &>/dev/null && return
+    sudo ip netns exec $1 ip link set $2 up > /dev/null 2>&1 && return
     sudo ip link add P type veth peer name Q
     give_interface_to_container P $1 $2
     give_interface_to_container Q $3 $4
@@ -91,7 +91,7 @@ create_point_to_point () {
 bridge_add_interface () {
     bridge=$1
     interface=$2
-    sudo brctl addif $bridge $interface &>/dev/null || return
+    sudo brctl addif $bridge $interface > /dev/null 2>&1 || return
     sudo ip link set dev $interface up
     echo Bridged interface: $interface
 }

--- a/playground/launch.sh
+++ b/playground/launch.sh
@@ -11,7 +11,7 @@ sudo modprobe ip_nat_ftp nf_conntrack_ftp
 
 # Make sure the bridge-control tools are installed.
 
-if [ ! -x /usr/local/sbin/brctl ]
+if [ ! -x /usr/local/sbin/brctl ] && (where tce-load > /dev/null 2>&1)
 then
     wget ftp://ftp.nl.netbsd.org/vol/2/metalab/distributions/tinycorelinux/4.x/x86/tcz/bridge-utils.tcz
     tce-load -i bridge-utils.tcz

--- a/playground/retest.sh
+++ b/playground/retest.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -x
+
+sudo ./stop.sh
+
+sudo sh -x ./launch.sh
+
+./test.sh
+

--- a/playground/stop.sh
+++ b/playground/stop.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo Stopping all running fopnp/ containers ...
+docker ps -a | grep fopnp/ | awk '{ print $1}' | xargs --no-run-if-empty docker stop -t=0
+
+echo Removing all fopnp/ containers ...
+docker ps -a | grep fopnp/ | awk '{ print $1}' | xargs --no-run-if-empty docker rm
+
+#docker rmi `sudo docker images 
+
+echo Removing remove interfaces created by launch.sh ...
+ifaces="h1-eth1 h2-eth1 h3-eth1 h4-eth1 exampleCOM homeA homeB modemA-eth1 modemB-eth1 example-eth1 ftp-eth0 mail-eth0 www-eth0"
+for i in $ifaces; do
+	ip link delete $i > /dev/null 2>&1
+done
+

--- a/playground/test.sh
+++ b/playground/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/expect
+
+eval spawn ssh -p 2201 brandon@localhost curl -I http://www.example.com
+#use correct prompt
+set prompt ":|#|\\\$"
+interact -o -nobuffer -re $prompt return
+send "abc123\r"
+interact
+


### PR DESCRIPTION
I have just encountered a problem building docker, due to something I think related to caching.
The build of base image failed during apt-get install, as it tries to use a package and gets 404-not-found.
I think it is because 'apt-get update' got cached and is not effectively executed for the base container but skipped. Probably related to "unless the RUN command _itself_ changes (and thus invalidates Docker’s on-host cache), Docker will reuse the previous results from cache" in http://thenewstack.io/understanding-the-docker-cache-for-faster-builds/.

This behavior might be specific to the revision of the docker ubuntu image I have on my PC.

$ sudo docker images ubuntu | grep 14.04
ubuntu              14.04               99ec81b80c55        6 months ago        266 MB

Anyway, this patch has solved the problem for me.
