### PR TITLE
Changing % style formatting to .format() style formatting.

### DIFF
--- a/py3/chapter05/blocks.py
+++ b/py3/chapter05/blocks.py
@@ -13,7 +13,7 @@ def recvall(sock, length):
     while length:
         block = sock.recv(length)
         if not block:
-            raise EOFError('socket closed with %d bytes left'
+            raise EOFError('socket closed with {} bytes left'
                            ' in this block'.format(length))
         length -= len(block)
         blocks.append(block)


### PR DESCRIPTION
Fixing a typo.

I would also argue that get block method should check for `b''` so you would not have to send empty block at the end of conversation and it would suffice just to close the socket. But that would create too much disparity between the book and the code I guess.
